### PR TITLE
Fix Gradle 9.0 deprecation issues

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,8 +58,9 @@ test {
 }
 
 license {
-    include '**/*.java'
-    include '**/*.groovy'
+    matching(includes: ['**/*.java', '**/*.groovy']) {
+        header = file('LICENSE')
+    }
 }
 
 gradlePlugin {


### PR DESCRIPTION
Gradle is removing public access to `ConfigureUtil` in Gradle 9. This PR replaces the usages of it, alongside Closures, with Gradle's own Actions. The `build.gradle` file was updated to use the `matching(Map, Action)` method as a test for this change.