### PR TITLE
1.1 - Remove usage of ConfigureUtil

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ For a simple project you only need to apply the licenser plugin to your project:
 
 ```gradle
 plugins {
-    id 'org.cadixdev.licenser' version '0.6.1'
+    id 'net.minecraftforge.licenser' version '1.1.0'
 }
 ```
 
@@ -88,11 +88,6 @@ The plugin can be configured using the `license` extension on the project.
     license {
         // Apply special license header to one source file
         matching('**/ThirdPartyLibrary.java') {
-            header = file('THIRDPARTY-LICENSE.txt')
-        }
-        
-        // Apply special license header to matching source files
-        matching(includes: ['**/thirdpartylibrary/**', '**/ThirdPartyLibrary.java']) {
             header = file('THIRDPARTY-LICENSE.txt')
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 
 
 group = 'net.minecraftforge'
-version gradleutils.tagOffsetVersion
+version = gradleutils.tagOffsetVersion
 println "Version: $version"
 
 repositories {
@@ -82,7 +82,7 @@ jar {
 }
 
 tasks.named('shadowJar', com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar) {
-    enableRelocation true
+    enableRelocation = true
     archiveClassifier = null
     relocationPrefix = 'net.minecraftforge.licenser.shadow'
     relocate 'org.cadixdev.gradle.licenser', 'net.minecraftforge.licenser'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
This PR marks the 1.1 update to Forge's licenser. I've done three things here:

1. Update Gradle to 8.13.
2. Remove usages of the now-deprecated ConfigureUtil.
   - As a byproduct of this, `license.matching(Map, Closure)` has been deleted since Gradle is removing support for configuring by map in Gradle 9.
3. Use proper assignment syntax in the buildscript.
   - Gradle 10 is updating the Groovy DSL, which removes support for assignment using Gradle's auto-generated 'propName value' syntax.

> [!NOTE]
> Once approved, this PR will not be merged through GitHub but rather will be manually squashed and pushed with the "1.1" tag.